### PR TITLE
Expand documentation

### DIFF
--- a/docs/source/background/index.rst
+++ b/docs/source/background/index.rst
@@ -64,7 +64,7 @@ References
 ----------
 .. [1] Dagestad, K.-F., Röhrs, J., Breivik, Ø., and Ådlandsvik, B.: OpenDrift v1.0: a generic framework for trajectory modelling, Geosci. Model Dev., 11, 1405-1420, https://doi.org/10.5194/gmd-11-1405-2018, 2018.
 
-.. [2] ANGE Team, Freshkiss3D home page. Available at: https://freshkiss3d.gforge.inria.fr/
+.. [2] ANGE Team, Freshkiss3D home page. Available at: https://freshkiss3d.gitlabpages.inria.fr/freshkiss3d/
 
 .. [3] Hydraulics, D. (2007). Delft3D-PART user manual version 2.13. WL| Delft Hydraulics, Delft.
 

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -22,3 +22,14 @@ Examples of the high-level API functionality are provided here. These examples r
    example11
    example12
    example13
+
+
+External Examples
+-----------------
+
+Below are links to examples of `dorado` being used in other projects.
+If you have used `dorado` as part of your project and have an example or graphic hosted online, please let us know and we will add a link to it here.
+
+`Tides on a simple 2D field <https://espin-2020.github.io/CoastalTeam/examples/HomogeneousField2D/HomogeneousField2D.html>`_ - an example of coupling `dorado` with `Landlab <https://landlab.github.io>`_.
+
+`Tides on a randomly vegetated field <https://espin-2020.github.io/CoastalTeam/examples/RandomField2D/RandomField2D.html>`_ - another example of coupling `dorado` with `Landlab <https://landlab.github.io>`_.

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -15,16 +15,6 @@ To `pip`-install this package, first ensure that you have the dependencies liste
     $ pip install pydorado
 
 
-Installation via `conda`
-------------------------
-.. note:: Some users have experienced dependency incompatibilities when installing via conda.
-
-To `conda`-install this package, use the following command:
-::
-
-    $ conda install -c elbeejay dorado
-
-
 Installation from source
 ------------------------
 1. Clone (or download) the repository

--- a/docs/source/misc/contributing.rst
+++ b/docs/source/misc/contributing.rst
@@ -4,6 +4,39 @@
 Contributing
 ============
 
-We welcome contributions to the dorado package. To contribute, we ask that pull requests be made to the `develop` branch on GitHub. Feel free to open up an issue beforehand to discuss the planned addition or modification.
+We welcome contributions to the dorado package in the form of pull requests and issues made in the source `repository <https://github.com/passaH2O/dorado>`_.
 
-As much as possible we try to stick to the `PEP-8 <https://www.python.org/dev/peps/pep-0008/>`_ standards for our code and `PEP-257 <https://www.python.org/dev/peps/pep-0257/>`_ standards for our docstrings.
+
+Issues
+------
+
+If you are having any problems using dorado we suggest opening an `issue <https://github.com/passaH2O/dorado/issues>`_.
+When you open an issue, please provide a clear description of what your scenario is, and what error message you are receiving.
+If possible, please include a minimal working example of some code that breaks, and the error output you receive.
+
+If there is some functionality you would like to see added to dorado you can also open an issue up to discuss that.
+This can be code you plan to write and contribute, or it can be something you would like to have available but are not comfortable coding yourself.
+Either way we are happy to help!
+
+
+Pull Requests
+-------------
+
+If you have a feature that you would like to propose be integrated into dorado, then you should open a `pull request <https://github.com/passaH2O/dorado/pulls>`_.
+To create a pull request, we recommend first `forking <https://guides.github.com/activities/forking/>`_ the repository, and then creating a separate branch to develop your feature (for reference see the `GitHub flow guide <https://guides.github.com/introduction/flow/>`_ and this `Git branching <https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging>`_ guide).
+Then you can commit and develop your feature in your branch.
+We ask that new features be accompanied by additional unit tests, to ensure that they operate as expected.
+For unit testing, we use `pytest <https://docs.pytest.org/en/latest/>`_.
+When you are satisfied with the code you have developed, you can open a pull request to the `"master" branch <https://github.com/passaH2O/dorado/tree/master>`_ of the project repository.
+Please write a concise and descriptive title for the pull request, and provide a clear description of what the feature does and why you are proposing its addition to the project.
+If your pull request does not pass our `continuous integration <https://docs.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration>`_ checks, then we will not be able to merge your addition into the code.
+We use `GitHub Actions <https://github.com/features/actions>`_ to ensure that dorado compiles and installs on MacOS, Windows, and Ubuntu on all supported versions of Python.
+Before developing any new code, you are more than welcome to open an issue first to discuss your proposed addition.
+
+
+Code Style
+----------
+
+To ensure consistency within the codebase, we follow some standard Python conventions for our formatting.
+As much as possible we try to stick to the `PEP-8 <https://www.python.org/dev/peps/pep-0008/>`_ standard for our code.
+For docstrings, we try to follow the `PEP-257 <https://www.python.org/dev/peps/pep-0257/>`_ standard.

--- a/docs/source/quickstart/demo01.rst
+++ b/docs/source/quickstart/demo01.rst
@@ -2,7 +2,12 @@
 
 Demo 1- Using the High-Level API
 --------------------------------
-In this demo, we show how particles can be routed along a simulated river delta, example output is from the delta simulation model, `DeltaRCM <https://github.com/DeltaRCM/pyDeltaRCM>`_. To do this, we will be using one of the high-level API functions provided in :download:`routines.py <../../../dorado/routines.py>`.
+In this demo, we show how particles can be routed along a simulated river delta, example output is from the delta simulation model, `DeltaRCM <https://github.com/DeltaRCM/pyDeltaRCM>`_.
+To do this, we will be using one of the high-level API functions provided in :download:`routines.py <../../../dorado/routines.py>`.
+A set of 50 particles will be seeded in the main channel of the synthetic delta.
+Then using information about the water depths and flow rates in the delta, the particles will be allowed to travel downstream.
+River deltas are distributary networks, and so the particles will not all travel along the same channels.
+By using a tool like `dorado`, simulated particles can help us answer questions related to hydrological connectivity and nutrient residence times in deltaic systems.
 
 First we load the sample parameters.
 
@@ -10,6 +15,7 @@ First we load the sample parameters.
 
     >>> from dorado.example_data import define_params as dp
     >>> import dorado as pr
+    >>> import matplotlib.pyplot as plt
     >>> rcmparams = dp.make_rcm_params()
 
 We can visualize the water depth for this scenario from the parameters. If you'd like to download this portion of the demo as a standalone script, it is available :download:`here <../pyplots/quickstart/demo1_depth.py>`.


### PR DESCRIPTION
So this PR does 4 things, largely in response to suggestions from [here](https://github.com/openjournals/joss-reviews/issues/2585#issuecomment-692365791).

1. Add links to external examples below our examples

2. Remove the instructions to `conda`-install the package as they were not working for all operating systems

3. Expand to contribution guidelines to make it the opening of issues and PRs more clear

4. Add "`import matplotlib.pyplot as plt`" to the first quickstart example. Also provide a bit more background information on that example, what is going on and why it might be of interest.

Edit: This would close #8 