### PR TITLE
Fix example pathing

### DIFF
--- a/docs/source/examples/example03.rst
+++ b/docs/source/examples/example03.rst
@@ -7,7 +7,7 @@ In this example we will demonstrate how to use the built-in animation functional
 
 To use the `animate_plots()` function, you must have installed the `ffmpeg <https://matplotlib.org/3.2.2/users/installing.html>`_ image writer.
 
-If you have run the previous example (:ref:`example02`), then you can run the following from the "examples/" folder and generate an animation similar to the one shown below.
+If you have run the previous example (:ref:`example02`), then you can run the following and generate an animation similar to the one shown below.
 
 Full example script available :download:`here <../../../examples/animate_deltarcm_particles.py>`.
 

--- a/docs/source/examples/example07.rst
+++ b/docs/source/examples/example07.rst
@@ -13,16 +13,17 @@ First run :ref:`example02`, and then we can access and use the particle travel i
 
    >>> import numpy as np
    >>> import json
+   >>> import os
    >>> from dorado.routines import draw_travel_path
    >>> data = np.load('ex_deltarcm_data.npz')
    >>> depth = data['depth']
-   >>> all_walk_data = json.load(open('steady_deltarcm_example/data/data.txt'))
+   >>> all_walk_data = json.load(open('steady_deltarcm_example'+os.sep+'data'+os.sep+'data.txt'))
 
 Now we will apply the `draw_travel_path` function. In this example we are going to visualize the travel paths of the first 4 particles, indicated by the list we are providing to the `draw_travel_path` function.
 
 .. doctest::
 
    >>> draw_travel_path(depth, all_walk_data, [0, 1, 2, 3],
-   >>>                  'steady_deltarcm_example/data/travel_paths.png')
+   >>>                  'steady_deltarcm_example'+os.sep+'data'+os.sep+'travel_paths.png')
 
 .. image:: images/example07/travel_paths.png

--- a/docs/source/examples/example08.rst
+++ b/docs/source/examples/example08.rst
@@ -12,17 +12,18 @@ First run :ref:`example01`, and then we can access and use the particle travel i
 .. doctest::
 
    >>> import numpy as np
+   >>> import os
    >>> import json
    >>> from dorado.routines import draw_travel_path
    >>> data = np.load('ex_anuga_data.npz')
    >>> depth = data['depth']
-   >>> all_walk_data = json.load(open('steady_anuga_example/data/data.txt'))
+   >>> all_walk_data = json.load(open('steady_anuga_example'+os.sep+'data'+os.sep+'data.txt'))
 
 Now we will apply the `draw_travel_path` function. In this example we are going to visualize the travel paths of the first 4 particles, indicated by the list we are providing to the `draw_travel_path` function.
 
 .. doctest::
 
    >>> draw_travel_path(depth, all_walk_data, [0,1,2,3],
-   >>>                  'steady_anuga_example/data/travel_paths.png')
+   >>>                  'steady_anuga_example'+os.sep+'data'+os.sep+'travel_paths.png')
 
 .. image:: images/example08/travel_paths.png

--- a/docs/source/examples/example12.rst
+++ b/docs/source/examples/example12.rst
@@ -5,6 +5,9 @@ Example 12 - Unsteady Flow Fields
 
 In this example we will revisit the `ANUGA <https://github.com/GeoscienceAustralia/anuga_core>`_ model domain we looked at in :ref:`example01`. This time, however, we will be routing our particles in an unsteady flow field, using the data contained in the `examples/example_data` subdirectory.
 
+.. Note::
+   This example must be run from the "examples" directory.
+
 Full example script available :download:`here <../../../examples/unsteady_example.py>`.
 
 First we have to load our modules and define the parameter items that are related to the cell size and the particle attributes (number, initial location).

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -6,6 +6,16 @@ Examples
 
 Examples of the high-level API functionality are provided here. These examples range from simple particle routing with a flow field, to measuring exposure time distributions for particle transport in a specified region. If your use case extends beyond the scenarios explored in these examples, we recommend using the `routines.py` script to help you design your own functions based on the lower-level methods in `particle_track.py`.
 
+.. Note::
+    To run :ref:`example12`, you must be in the "examples" directory. Pathing
+    to the data for that example is relative to the working directory and
+    assumes you are in the "examples" directory.
+
+    Similarly, for :ref:`example03`, :ref:`example07`, and :ref:`example08`
+    these must be run from the same location (same directory) from which you
+    ran the prerequisite example (e.g. :ref:`example02` must be run before
+    :ref:`example03`)
+
 .. toctree::
    :maxdepth: 1
 

--- a/examples/draw_anuga_particle_paths.py
+++ b/examples/draw_anuga_particle_paths.py
@@ -2,16 +2,19 @@
 # Can only be run after steady_anuga_particles.py has been successfully run
 import numpy as np
 import os
+import os.path
 import json
 from dorado.routines import draw_travel_path
 
-### load the depth data
-data = np.load('ex_anuga_data.npz')
+# load the depth data
+f_path = os.path.abspath(os.path.dirname(__file__))
+data_path = os.path.join(f_path, 'ex_anuga_data.npz')
+data = np.load(data_path)
 depth = data['depth']
 
-### load the walk data
+# load the walk data
 all_walk_data = json.load(open('steady_anuga_example'+os.sep+'data'+os.sep+'data.txt'))
 
-### Draw the travel path
-draw_travel_path(depth, all_walk_data, [0,1,2,3],
+# Draw the travel path
+draw_travel_path(depth, all_walk_data, [0, 1, 2, 3],
                  'steady_anuga_example'+os.sep+'data'+os.sep+'travel_paths.png')

--- a/examples/draw_deltarcm_particle_paths.py
+++ b/examples/draw_deltarcm_particle_paths.py
@@ -2,10 +2,13 @@
 # Can only be run after steady_deltarcm_particles.py has been successfully run
 import numpy as np
 import json
+import os.path
 from dorado.routines import draw_travel_path
 
 # load the depth data
-data = np.load('ex_deltarcm_data.npz')
+f_path = os.path.abspath(os.path.dirname(__file__))
+data_path = os.path.join(f_path, 'ex_deltarcm_data.npz')
+data = np.load(data_path)
 depth = data['depth']
 
 # load the walk data

--- a/examples/draw_deltarcm_particle_paths.py
+++ b/examples/draw_deltarcm_particle_paths.py
@@ -2,6 +2,7 @@
 # Can only be run after steady_deltarcm_particles.py has been successfully run
 import numpy as np
 import json
+import os
 import os.path
 from dorado.routines import draw_travel_path
 

--- a/examples/parallel_comparison.py
+++ b/examples/parallel_comparison.py
@@ -1,6 +1,7 @@
 """Make an example of the workflow with gridded Anuga output data."""
 
 import numpy as np
+import os.path
 import time
 from dorado.parallel_routing import parallel_routing
 
@@ -11,8 +12,10 @@ import dorado.particle_track as pt
 # create params and then assign the parameters
 params = pt.params()
 
-# load some variables from a deltarcm output so stage is varied
-data = np.load('ex_anuga_data.npz')
+# load some variables from an anuga output so stage is varied
+f_path = os.path.abspath(os.path.dirname(__file__))
+data_path = os.path.join(f_path, 'ex_anuga_data.npz')
+data = np.load(data_path)
 
 # pull depth and stage from that data
 depth = data['depth']

--- a/examples/set_timestep_anuga_particles.py
+++ b/examples/set_timestep_anuga_particles.py
@@ -1,14 +1,17 @@
-"""Example of the workflow with gridded anuga output data"""
+"""Example of the workflow with gridded anuga output data."""
 
 import numpy as np
+import os.path
 import dorado.particle_track as pt
 from dorado.particle_track import params
 from dorado.routines import get_state
 from dorado.routines import plot_state
 import matplotlib.pyplot as plt
 
-# load some variables from a deltarcm output so stage is varied
-data = np.load('ex_anuga_data.npz')
+# load some variables from an anuga output so stage is varied
+f_path = os.path.abspath(os.path.dirname(__file__))
+data_path = os.path.join(f_path, 'ex_anuga_data.npz')
+data = np.load(data_path)
 
 # pull depth and stage from that data
 depth = data['depth']

--- a/examples/steady_anuga_particles.py
+++ b/examples/steady_anuga_particles.py
@@ -1,11 +1,14 @@
 """Make an example of the workflow with gridded anuga output data."""
 
 import numpy as np
+import os.path
 from dorado.routines import steady_plots
 import dorado.particle_track as pt
 
 # load some variables from a anuga output so stage is varied
-data = np.load('ex_anuga_data.npz')
+f_path = os.path.abspath(os.path.dirname(__file__))
+data_path = os.path.join(f_path, 'ex_anuga_data.npz')
+data = np.load(data_path)
 
 # pull depth and stage from that data
 depth = data['depth']

--- a/examples/steady_deltarcm_particles.py
+++ b/examples/steady_deltarcm_particles.py
@@ -1,11 +1,14 @@
 """Make an example of the workflow with deltarcm output data."""
 
 import numpy as np
+import os.path
 from dorado.routines import steady_plots
 from dorado.particle_track import params
 
 # load some variables from a deltarcm output so stage is varied
-data = np.load('ex_deltarcm_data.npz')
+f_path = os.path.abspath(os.path.dirname(__file__))
+data_path = os.path.join(f_path, 'ex_deltarcm_data.npz')
+data = np.load(data_path)
 
 # pull depth and stage from that data
 stage = data['stage']

--- a/examples/steepest_descent_deltarcm.py
+++ b/examples/steepest_descent_deltarcm.py
@@ -1,11 +1,14 @@
-"""Example of the workflow with deltarcm output data"""
+"""Example of the workflow with deltarcm output data."""
 
 import numpy as np
+import os.path
 from dorado.routines import steady_plots
 from dorado.particle_track import params
 
 # load some variables from a deltarcm output so stage is varied
-data = np.load('ex_deltarcm_data.npz')
+f_path = os.path.abspath(os.path.dirname(__file__))
+data_path = os.path.join(f_path, 'ex_deltarcm_data.npz')
+data = np.load(data_path)
 
 # pull depth and stage from that data
 stage = data['stage']

--- a/examples/timing_anuga_particles.py
+++ b/examples/timing_anuga_particles.py
@@ -1,11 +1,14 @@
 """Example of the workflow with gridded anuga output data"""
 
 import numpy as np
+import os.path
 from dorado.routines import time_plots
 from dorado.particle_track import params
 
-# load some variables from a deltarcm output so stage is varied
-data = np.load('ex_anuga_data.npz')
+# load some variables from an anuga output so stage is varied
+f_path = os.path.abspath(os.path.dirname(__file__))
+data_path = os.path.join(f_path, 'ex_anuga_data.npz')
+data = np.load(data_path)
 
 # pull depth and stage from that data
 depth = data['depth']
@@ -21,8 +24,8 @@ params.stage = depth  # using depth as stand-in for stage in this example
 params.qx = qx
 params.qy = qy
 
-params.seed_xloc = list(range(20,30))
-params.seed_yloc = list(range(48,53))
+params.seed_xloc = list(range(20, 30))
+params.seed_yloc = list(range(48, 53))
 params.Np_tracer = 50
 params.dx = 50.
 params.theta = 1.0

--- a/examples/unsteady_example.py
+++ b/examples/unsteady_example.py
@@ -1,4 +1,5 @@
 """Unsteady flow example using gridded anuga output data."""
+# Note: This example must be run from within the 'examples' directory!!!
 
 from dorado.routines import unsteady_plots
 import dorado.particle_track as pt


### PR DESCRIPTION
This resolves the issue at the root of #10, which is that the file paths used to load the example data in the provided example scripts used a *relative* path and we should have been using an *absolute* path based on the location of the example script itself. 

These changes allow a user to call an example script from any directory on their machine and the script will be able to find the associated example data without a problem.

Notes have been added to clarify where this is not the case (the unsteady case must be run from the "examples" directory), and to make clear that sequential examples must be run from the same directory (e.g. if you run a steady example from the root directory, an example reliant on that output, such as the animation example, must be run from the root directory as well).

In this PR we also generalize some of the file paths in the documented examples so that they are OS-agnostic in the rendered documentation (not just in the script `.py` files). 