### PR TITLE
Weights speedup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,10 +116,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - name: Set up Python 3.8
+    - name: Set up Python 3.x
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/docs/source/paper/index.rst
+++ b/docs/source/paper/index.rst
@@ -4,4 +4,4 @@
 Paper
 =====
 
-A paper accompanying this software package is currently being submitted to the Journal of Open Source Software. The paper Markdown file has been rendered as a ReStructured Text file (although not all formatting translates well) for inclusion in the documentation prior to publication. It can be viewed :ref:`here<paperrst>`.
+A paper accompanying this software package has been published in the Journal of Open Source Software. It can be viewed `here <https://joss.theoj.org/papers/10.21105/joss.02585>`_

--- a/docs/source/paper/paper.rst
+++ b/docs/source/paper/paper.rst
@@ -1,7 +1,0 @@
-.. _paperrst:
-
-==================
-RST-Rendered Paper
-==================
-
-.. mdinclude:: ../../../joss/paper.md

--- a/docs/source/userguide/index.rst
+++ b/docs/source/userguide/index.rst
@@ -53,6 +53,14 @@ Defining the `Particles`
 
 Defining a :obj:`dorado.particle_track.Particles` class is a key step in using `dorado` to perform particle routing. To define a set of particles, the model parameters must first be defined as described above. The `Particles` class is initialized using an instance of the model parameters. From there, particles can be generated and routed.
 
+.. Note::
+    When :obj:`dorado.particle_track.Particles` is initialized, all of the
+    routing weights are automatically calculated. This may take some time for
+    larger model domains, but allows for faster particle routing when particles
+    are actually moved through the domain. There is a progress bar associated
+    with this process so you don't feel like Python has gotten stuck in the
+    object initialization.
+
 Particle Generation and Routing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/dorado/__init__.py
+++ b/dorado/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 
 from . import lagrangian_walker
 from . import parallel_routing

--- a/dorado/lagrangian_walker.py
+++ b/dorado/lagrangian_walker.py
@@ -9,6 +9,7 @@ from builtins import range, map
 from math import cos
 import numpy as np
 from numpy.random import random
+from tqdm import tqdm
 
 
 def random_pick_seed(choices, probs=None):
@@ -44,22 +45,28 @@ def make_weight(Particles):
     L, W = np.shape(Particles.stage)
     Particles.weight = np.zeros((L, W, 9))
     # do weighting calculation for each cell
-    for i in range(1, L-1):
-        for j in range(1, W-1):
+    print('Calculating routing weights ...')
+    for i in tqdm(list(range(1, L-1)), ascii=True):
+        for j in list(range(1, W-1)):
             # weights for each location in domain
+            # get stage values for neighboring cells
             stage_ind = Particles.stage[i-1:i+2, j-1:j+2]
 
+            # calculate surface slope weights
             weight_sfc = np.maximum(0,
                                     (Particles.stage[i, j]-stage_ind) /
                                     Particles.distances)
 
+            # calculate inertial component weights
             weight_int = np.maximum(0, ((Particles.qx[i, j] * Particles.jvec +
                                          Particles.qy[i, j] * Particles.ivec) /
                                     Particles.distances))
 
+            # get depth and cell types for neighboring cells
             depth_ind = Particles.depth[i-1:i+2, j-1:j+2]
             ct_ind = Particles.cell_type[i-1:i+2, j-1:j+2]
 
+            # set weights for cells that are too shallow, or invalid 0
             weight_sfc[(depth_ind <= Particles.dry_depth) | (ct_ind == 2)] = 0
             weight_int[(depth_ind <= Particles.dry_depth) | (ct_ind == 2)] = 0
 
@@ -91,12 +98,14 @@ def make_weight(Particles):
             # set weight in the true weight array
             Particles.weight[i, j, :] = weight.ravel()
 
+    print('Finished routing weight calculation.')
+
 
 def get_weight(Particles, ind):
-    """Assign weights to cells surrounding current index.
+    """Choose new cell location given an initial location.
 
-    Function to assign weights to the surrounding 8 cells around the
-    current index and randomly choose one of those cells.
+    Function to randomly choose 1 of the surrounding 8 cells around the
+    current index using the pre-calculated routing weights.
 
     **Inputs** :
 
@@ -112,50 +121,8 @@ def get_weight(Particles, ind):
             New location given as a value between 1 and 8 (inclusive)
 
     """
-    # # pull surrounding cell values from stage array
-    # stage_ind = Particles.stage[ind[0]-1:ind[0]+2, ind[1]-1:ind[1]+2]
-    # # define water surface gradient weight component (minimum of 0)
-    # weight_sfc = np.maximum(0,
-    #                         (Particles.stage[ind] - stage_ind) /
-    #                         Particles.distances)
-    #
-    # # define flow inertial weighting component (minimum of 0)
-    # weight_int = np.maximum(0, (Particles.qx[ind] * Particles.jvec +
-    #                             Particles.qy[ind] * Particles.ivec) /
-    #                         Particles.distances)
-    #
-    # # pull surrounding cell values from depth and cell type arrays
-    # depth_ind = Particles.depth[ind[0]-1:ind[0]+2, ind[1]-1:ind[1]+2]
-    # ct_ind = Particles.cell_type[ind[0]-1:ind[0]+2, ind[1]-1:ind[1]+2]
-    #
-    # # if the depth is below minimum depth for cell to be weight
-    # # or it is a cell type that is not water, then make it impossible for
-    # # the parcel to travel there by setting associated weight to 0
-    # weight_sfc[(depth_ind <= Particles.dry_depth) | (ct_ind == 2)] = 0
-    # weight_int[(depth_ind <= Particles.dry_depth) | (ct_ind == 2)] = 0
-    #
-    # # if sum of weights is above 0 normalize by sum of weights
-    # if np.nansum(weight_sfc) > 0:
-    #     weight_sfc = weight_sfc / np.nansum(weight_sfc)
-    # # if sum of weight is above 0 normalize by sum of weights
-    # if np.nansum(weight_int) > 0:
-    #     weight_int = weight_int / np.nansum(weight_int)
-    #
-    # # define actual weight by using gamma, and defined weight components
-    # Particles.weight = Particles.gamma * weight_sfc + \
-    #     (1 - Particles.gamma) * weight_int
-    # # modify the weight by the depth and theta weighting parameter
-    # Particles.weight = depth_ind ** Particles.theta * Particles.weight
-    # # if the depth is below the minimum depth then location is not
-    # # considered therefore set the associated weight to nan
-    # Particles.weight[(depth_ind <= Particles.dry_depth) | (ct_ind == 2)] \
-    #     = np.nan
-    # # if it's a dead end with only nans and 0's, choose deepest cell
-    # if np.nansum(Particles.weight) <= 0:
-    #     Particles.weight = np.zeros_like(Particles.weight)
-    #     Particles.weight[depth_ind == np.max(depth_ind)] = 1.0
     # randomly pick the new cell for the particle to move to using the
-    # random_pick function and the set of weights just defined
+    # random_pick function and the set of weights
     if Particles.steepest_descent is not True:
         new_cell = random_pick(Particles.weight[ind[0], ind[1], :])
     elif Particles.steepest_descent is True:
@@ -365,8 +332,8 @@ def steep_descent(probs):
 
     """
     max_val = np.nanmax(probs)
-    # remove location 1,1 from consideration
-    probs[1, 1] = 0
+    # remove initial location (index 4) from consideration
+    probs[4] = 0
     # remove any locations from consideration beneath max value
     probs[probs < max_val] = 0
     # any nans become ignored too

--- a/dorado/lagrangian_walker.py
+++ b/dorado/lagrangian_walker.py
@@ -41,6 +41,9 @@ def random_pick_seed(choices, probs=None):
 
 def make_weight(Particles):
     """Make an array with the routing weights."""
+    # local namespace function imports
+    from numpy import maximum
+    from numpy import nansum
     # init the weight array
     L, W = np.shape(Particles.stage)
     Particles.weight = np.zeros((L, W, 9))
@@ -53,14 +56,14 @@ def make_weight(Particles):
             stage_ind = Particles.stage[i-1:i+2, j-1:j+2]
 
             # calculate surface slope weights
-            weight_sfc = np.maximum(0,
-                                    (Particles.stage[i, j]-stage_ind) /
-                                    Particles.distances)
+            weight_sfc = maximum(0,
+                                 (Particles.stage[i, j]-stage_ind) /
+                                 Particles.distances)
 
             # calculate inertial component weights
-            weight_int = np.maximum(0, ((Particles.qx[i, j] * Particles.jvec +
-                                         Particles.qy[i, j] * Particles.ivec) /
-                                    Particles.distances))
+            weight_int = maximum(0, ((Particles.qx[i, j] * Particles.jvec +
+                                      Particles.qy[i, j] * Particles.ivec) /
+                                 Particles.distances))
 
             # get depth and cell types for neighboring cells
             depth_ind = Particles.depth[i-1:i+2, j-1:j+2]
@@ -71,12 +74,12 @@ def make_weight(Particles):
             weight_int[(depth_ind <= Particles.dry_depth) | (ct_ind == 2)] = 0
 
             # if sum of weights is above 0 normalize by sum of weights
-            if np.nansum(weight_sfc) > 0:
-                weight_sfc = weight_sfc / np.nansum(weight_sfc)
+            if nansum(weight_sfc) > 0:
+                weight_sfc = weight_sfc / nansum(weight_sfc)
 
             # if sum of weight is above 0 normalize by sum of weights
-            if np.nansum(weight_int) > 0:
-                weight_int = weight_int / np.nansum(weight_int)
+            if nansum(weight_int) > 0:
+                weight_int = weight_int / nansum(weight_int)
 
             # define actual weight by using gamma, and weight components
             weight = Particles.gamma * weight_sfc + \
@@ -91,7 +94,7 @@ def make_weight(Particles):
                 = np.nan
 
             # if it's a dead end with only nans and 0's, choose deepest cell
-            if np.nansum(weight) <= 0:
+            if nansum(weight) <= 0:
                 weight = np.zeros_like(weight)
                 weight[depth_ind == np.max(depth_ind)] = 1.0
 

--- a/dorado/particle_track.py
+++ b/dorado/particle_track.py
@@ -379,6 +379,9 @@ class Particles():
         # initialize the walk_data
         self.walk_data = None
 
+        # create weights
+        lw.make_weight(self)
+
     # function to clear walk data if you've made a mistake while generating it
     def clear_walk_data(self):
         """Manually reset self.walk_data back to None."""

--- a/dorado/particle_track.py
+++ b/dorado/particle_track.py
@@ -379,7 +379,7 @@ class Particles():
         # initialize the walk_data
         self.walk_data = None
 
-        # create weights
+        # create weights - this might take a bit of time for large domains
         lw.make_weight(self)
 
     # function to clear walk data if you've made a mistake while generating it

--- a/tests/test_lagrangian_walker.py
+++ b/tests/test_lagrangian_walker.py
@@ -222,3 +222,36 @@ def test_get_weight_deep():
     np.random.seed(0)
     # make assertion
     assert lw.get_weight(particles, ind) == 8
+
+
+def test_make_weight_deep():
+    '''
+    Test for function make_weight within lagrangian_walker
+    '''
+    tools = pt.modelParams()
+    # define a bunch of expected values
+    tools.stage = np.ones((5, 5))
+    tools.cell_type = np.zeros_like(tools.stage)
+    tools.qy = tools.stage.copy()
+    tools.qx = np.zeros((5, 5))
+    tools.ivec = ivec
+    tools.jvec = jvec
+    tools.distances = distances*np.nan
+    tools.dry_depth = 0.1
+    tools.gamma = 0.02
+    tools.theta = 1
+    tools.steepest_descent = True
+    tools.depth = tools.stage.copy()
+    tools.depth[2,2] = 10.0  # define index 8 as the deepest
+    tools.seed_xloc = [1]
+    tools.seed_yloc = [1]
+    tools.Np_tracer = 1
+    tools.dx = 1
+    # define particles
+    particles = pt.Particles(tools)
+    # set the current index
+    ind = (1,1)
+    # set seed
+    np.random.seed(0)
+    # make assertion
+    assert lw.get_weight(particles, ind) == 8

--- a/tests/test_particle_track.py
+++ b/tests/test_particle_track.py
@@ -124,6 +124,31 @@ def test_exact_locations():
     assert all_walk_data['xinds'][0] == seed_xloc
     assert all_walk_data['yinds'][0] == seed_yloc
 
+def test_exact_locations_overflow():
+    """Test where number of particles exceeds number of seed locations."""
+    num_ps = 3
+    particle = particle_track.Particles(params)
+    particle.generate_particles(num_ps, [0, 1], [0, 1], method='exact')
+    all_walk_data = particle.run_iteration()
+    assert len(all_walk_data['xinds']) == num_ps
+    assert len(all_walk_data['yinds']) == num_ps
+
+def test_no_explicit_generation():
+    """Test reading of Np_tracer from self if some walk_data exists."""
+    # create some walk data (would exist from a previous run)
+    walk_data = {'xinds': [[1], [1]], 'yinds': [[1], [1]],
+                 'travel_times': [[0.0], [0.0]]}
+    # init particle class and stick walk data in it
+    # init defines Np_tracer as 0, but it is 2 in walk_data
+    particle = particle_track.Particles(params)
+    particle.walk_data = walk_data
+    # assert that Np_tracer is 0
+    assert particle.Np_tracer == 0
+    # run an iteration and see if Np_tracer is corrected
+    particle.run_iteration()
+    # assert that number of particles has been correctly identified
+    assert particle.Np_tracer == 2
+
 def test_travel_time():
     # Particle doesn't travel in the 3x3 space due to the 'sticky' edge
     # conditions so check that travel time is 0 and particle hasn't moved


### PR DESCRIPTION
### speeding up the random walk
This PR takes a suggestion from @wrightky, and separates the routing weight creation from the actual particle random walking itself. Actual use of the code does not change at all from the perspective of someone running functions in `routines.py` or calling `run_iteration()` from `particle_track.py` (which is good). 

Internally this PR split `get_weight()` into `make_weight()` and `get_weight()` in `lagrangian_walker.py`. 
- `make_weight()` is called when the `Particles` class is initialized. All of the routing weights are computed at that time and stored in a L x W x 9 array (where L and W are the length and width of the domain). A progress bar was added for this initialization as it may take some time on larger domains. 
- `get_weight()` is now a pretty small function that just calls either the random picker or steepest descent function, depending on the parameters of the run

Example scripts seem to run at about the same speed as they used to, as most of their processing time gets tied up in plot creation and saving. But I think that for people using the `run_iteration()` functions to simulate many particles, this change will greatly speed things up. 

**Note:** Unit tests of example cases and checks on individual particle stepping all pass because while the weighting calculation is changed, the "random selection" process for the particle walking hasn't changed - meaning that previous tests which set up the rng-seed to create deterministic (reproducible) results are still working! This also implies that any previous simulations conducted with `dorado` will be identical to new ones, the new simulations will just run faster.

This PR also closes #16 by allowing the documentation to be built on Python 3.9. This implies that `dorado` will work on Python 3.9, but as we don't explicitly run unit tests on Python 3.9 I don't know that we should say we 'officially' support it ... yet.

### Speed comparisons
Comparing the speed of particle routing for code in this PR vs current code. All conditions are steady flow fields, and particles are stepped by iterating over `run_iteration()` a bunch of times (no routines are used), each condition in the table below is run 3 times and an approximate average time is reported. These are tests run on the example domains. Also worth mentioning is that these time tests were run on Python 3.8.3.

| Domain Used | Number of Particles | Number of Iterations | Current Speed [s] | This PR [s] |
| :-: | :-: | :-: | :-: | :-: |
| anuga example domain | 100 | 50 | 0.8 | 1.3 |
| anuga example domain | 1000 | 50 | 8.0 | 2.6 |
| anuga example domain | 5000 | 50 | 41.0 | 8.1 |
| deltarcm example domain | 100 | 50 | 0.7 | 3.5 |
| deltarcm example domain | 1000 | 50 | 7.5 | 4.8 |
| deltarcm example domain | 5000 | 50 | 38.0 | 10.2 |

The new method of computing weights a priori costs some time upfront compared to the current method of computing weights on the fly. This makes simulations with few particles slower with the new method. Once the number of particles becomes large enough however, the cost of computing weights on the fly catches up to the a priori method - on the example domains the method in this PR is 3-5x faster than the current implementation when 5,000 particles are simulated.

### outstanding items to complete before PR is 'ready'
- [x] additional testing to ensure weights are being generated as expected
- [x] more tests for "edge" cases in both senses of the word (are boundaries acting as expected?)
- [x] added test to ensure that "overflow" scenario in 'exact' particle generation works (e.g. when number of particles exceeds seed locations the assignment loops through seed locations until all particles are generated)
- [x] added test for scenarios where `walk_data` is defined but the `Particles` object does not have explicit information about `Np_tracer` (number of particles). test to ensure that this is properly counted when `run_iteration()` is used to iterate the particles in `walk_data`
- [x] some actual time tests against current code to better gauge speed-up
- [x] check parallel code to ensure weights only get calculated once there (to ensure it is faster than serial code) - yes, one of the inputs to the `parallel_routing()` function is a pre-initialized `Particles` class
- [x] make any necessary changes to documentation to cover this procedural change (weight computation a priori vs for each step)
- [x] increment version number in `__init__.py`