### PR TITLE
Optimize weights computation

### DIFF
--- a/dorado/__init__.py
+++ b/dorado/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.2"
+__version__ = "2.5.0"
 
 
 from . import lagrangian_walker

--- a/dorado/lagrangian_walker.py
+++ b/dorado/lagrangian_walker.py
@@ -39,56 +39,189 @@ def random_pick_seed(choices, probs=None):
     return choices[idx]
 
 
-def make_weight(Particles, ind):
-    """Update weighting array with weights at this index"""
-    # get stage values for neighboring cells
-    stage_ind = Particles.stage[ind[0]-1:ind[0]+2, ind[1]-1:ind[1]+2]
+def big_sliding_window(raster):
+    """Creates 3D array organizing local neighbors at every index
 
+    Returns a raster of shape (L,W,9) which organizes (along the third
+    dimension) all of the neighbors in the original raster at a given
+    index, in the order [NW, N, NE, W, 0, E, SW, S, SE]. Outputs are
+    ordered to match np.ravel(), so it functions similarly to a loop
+    applying ravel to the elements around each index.
+    For example, the neighboring values in raster indexed at (i,j) are 
+    raster(i-1:i+2, j-1:j+2).ravel(). These 9 values have been mapped to
+    big_ravel(i,j,:) for ease of computations. Helper function for make_weight.
+
+    **Inputs** :
+
+        raster : `ndarray`
+            2D array of values (e.g. stage, qx)
+
+    **Outputs** :
+
+        big_ravel : `ndarray`
+            3D array which sorts the D8 neighbors at index (i,j) in 
+            raster into the 3rd dimension at (i,j,:)
+
+    """
+    big_ravel = np.zeros((raster.shape[0],raster.shape[1],9))
+    big_ravel[1:-1,1:-1,0] = raster[0:-2,0:-2]
+    big_ravel[1:-1,1:-1,1] = raster[0:-2,1:-1]
+    big_ravel[1:-1,1:-1,2] = raster[0:-2,2:]
+    big_ravel[1:-1,1:-1,3] = raster[1:-1,0:-2]
+    big_ravel[1:-1,1:-1,4] = raster[1:-1,1:-1]
+    big_ravel[1:-1,1:-1,5] = raster[1:-1,2:]
+    big_ravel[1:-1,1:-1,6] = raster[2:,0:-2]
+    big_ravel[1:-1,1:-1,7] = raster[2:,1:-1]
+    big_ravel[1:-1,1:-1,8] = raster[2:,2:]
+
+    return big_ravel
+
+
+def tile_local_array(local_array, L, W):
+    """Take a local array [[NW, N, NE], [W, 0, E], [SW, S, SE]]
+    and repeat it into an array of shape (L,W,9), where L, W are
+    the shape of the domain, and the original elements are ordered
+    along the third axis. Helper function for make_weight.
+
+    **Inputs** :
+
+        local_array : `ndarray`
+            2D array of represnting the D8 neighbors around
+            some index (e.g. ivec, jvec)
+
+        L : `int`
+            Length of the domain
+
+        W : `int`
+            Width of the domain
+
+    **Outputs** :
+
+        tiled_array : `ndarray`
+            3D array repeating local_array.ravel() LxW times
+
+    """
+    return np.tile(local_array.ravel(), (L, W, 1))
+
+
+def tile_domain_array(raster):
+    """Repeat a large 2D array 9 times along the third axis.
+    Helper function for make_weight.
+
+    **Inputs** :
+
+        raster : `ndarray`
+            2D array of values (e.g. stage, qx)
+
+    **Outputs** :
+
+        tiled_array : `ndarray`
+            3D array repeating raster 9 times
+
+    """
+    return np.repeat(raster[:, :, np.newaxis], 9, axis=2)
+
+
+def clear_borders(tiled_array):
+    """Set to zero all the edge elements of a vertical stack 
+    of 2D arrays. Helper function for make_weight.
+
+    **Inputs** :
+
+        tiled_array : `ndarray`
+            3D array repeating raster (e.g. stage, qx) 9 times
+            along the third axis
+
+    **Outputs** :
+
+        tiled_array : `ndarray`
+            The same 3D array as the input, but with the borders
+            in the first and second dimension set to 0.
+
+    """
+    raster[0,:,:] = 0.
+    raster[:,0,:] = 0.
+    raster[-1,:,:] = 0.
+    raster[:,-1,:] = 0.
+    return
+
+
+def make_weight(Particles):
+    """Create the weighting array for particle routing
+
+    Function to compute the routing weights at each index, which gets
+    stored inside the :obj:`dorado.particle_track.Particles` object
+    for use when routing. Called when the object gets instantiated.
+
+    **Inputs** :
+
+        Particles : :obj:`dorado.particle_track.Particles`
+            A :obj:`dorado.particle_track.Particles` object
+
+    **Outputs** :
+
+        Updates the weights array inside the
+        :obj:`dorado.particle_track.Particles` object
+
+    """
+    print('Calculating routing weights ...')
+    L, W = Particles.stage.shape
+    
     # calculate surface slope weights
-    weight_sfc = maximum(0,
-                         (Particles.stage[ind] - stage_ind) /
-                         Particles.distances)
-
+    weight_sfc = (tile_domain_array(Particles.stage) \
+                  - big_sliding_window(Particles.stage))
+    weight_sfc /= tile_local_array(Particles.distances, L, W)
+    weight_sfc[weight_sfc <= 0] = 0
+    clear_borders(weight_sfc)
+    
     # calculate inertial component weights
-    weight_int = maximum(0, ((Particles.qx[ind] * Particles.jvec +
-                              Particles.qy[ind] * Particles.ivec) /
-                         Particles.distances))
-
+    weight_int = (tile_domain_array(Particles.qx)*tile_local_array(Particles.jvec, L, W)) \
+                 + (tile_domain_array(Particles.qy)*tile_local_array(Particles.ivec, L, W))
+    weight_int /= tile_local_array(Particles.distances, L, W)
+    weight_int[weight_int <= 0] = 0
+    clear_borders(weight_int)
+    
     # get depth and cell types for neighboring cells
-    depth_ind = Particles.depth[ind[0]-1:ind[0]+2, ind[1]-1:ind[1]+2]
-    ct_ind = Particles.cell_type[ind[0]-1:ind[0]+2, ind[1]-1:ind[1]+2]
+    depth_ind = big_sliding_window(Particles.depth)
+    ct_ind = big_sliding_window(Particles.cell_type)
 
     # set weights for cells that are too shallow, or invalid 0
     weight_sfc[(depth_ind <= Particles.dry_depth) | (ct_ind == 2)] = 0
     weight_int[(depth_ind <= Particles.dry_depth) | (ct_ind == 2)] = 0
-
+    
     # if sum of weights is above 0 normalize by sum of weights
-    if nansum(weight_sfc) > 0:
-        weight_sfc = weight_sfc / nansum(weight_sfc)
-
-    # if sum of weight is above 0 normalize by sum of weights
-    if nansum(weight_int) > 0:
-        weight_int = weight_int / nansum(weight_int)
+    norm_sfc = np.nansum(weight_sfc, axis=2)
+    idx_sfc = tile_domain_array((norm_sfc > 0))
+    weight_sfc[idx_sfc] /= tile_domain_array(norm_sfc)[idx_sfc]
+    
+    norm_int = np.nansum(weight_int, axis=2)
+    idx_int = tile_domain_array((norm_int > 0))
+    weight_int[idx_int] /= tile_domain_array(norm_int)[idx_int]
 
     # define actual weight by using gamma, and weight components
     weight = Particles.gamma * weight_sfc + \
-        (1 - Particles.gamma) * weight_int
-
+             (1 - Particles.gamma) * weight_int
+    
     # modify the weight by the depth and theta weighting parameter
     weight = depth_ind ** Particles.theta * weight
-
+    
     # if the depth is below the minimum depth then location is not
     # considered therefore set the associated weight to nan
-    weight[(depth_ind <= Particles.dry_depth) | (ct_ind == 2)] \
-        = np.nan
+    weight[(depth_ind <= Particles.dry_depth) | (ct_ind == 2)] = 0
 
     # if it's a dead end with only nans and 0's, choose deepest cell
-    if nansum(weight) <= 0:
-        weight = np.zeros_like(weight)
-        weight[depth_ind == np.max(depth_ind)] = 1.0
+    zero_weights = tile_domain_array((np.nansum(weight, axis=2) <= 0))
+    deepest_cells = (depth_ind == tile_domain_array(np.max(depth_ind, axis=2)))
+    choose_deep_cells = (zero_weights & deepest_cells)
+    weight[choose_deep_cells] = 1.0
+
+    # Final checks, eliminate invalid choices
+    clear_borders(weight)
+    weight[:,:,4] = 0.
 
     # set weight in the true weight array
-    Particles.weight[ind[0], ind[1], :] = weight.ravel()
+    Particles.weight = weight
+    print('Done')
 
 
 def get_weight(Particles, ind):
@@ -111,9 +244,6 @@ def get_weight(Particles, ind):
             New location given as a value between 1 and 8 (inclusive)
 
     """
-    # Check if weights have been computed for this location:
-    if nansum(Particles.weight[ind[0], ind[1], :]) <= 0:
-        make_weight(Particles, ind)
     # randomly pick the new cell for the particle to move to using the
     # random_pick function and the set of weights
     if Particles.steepest_descent is not True:

--- a/dorado/particle_track.py
+++ b/dorado/particle_track.py
@@ -402,7 +402,7 @@ class Particles():
         self.walk_data = None
 
         # initialize routing weights array
-        self.weight = np.zeros((self.stage.shape[0], self.stage.shape[1], 9))
+        lw.make_weight(self)
 
 
     # function to clear walk data if you've made a mistake while generating it


### PR DESCRIPTION
I have one more thing to add to this PR before committing (change routine plotting to re-use plots, also a speed improvement) but I'll go ahead and open it up now for feedback. 

Recasts the algorithm used in `make_weights` to compute weights everywhere using a few big array operations, rather than many small array operations inside a for-loop. Takes advantage of the AVX architecture in `numpy` to do many operations at once under the hood inside the CPU, which I expect is more optimal than any algorithm we could've gotten from scratch.

Had to introduce a few helper functions to get the process worked out and clean, so here's the breakdown of how those functions are used:
- `make_weight` performs the same steps as before, except instead of being performed locally around some index `(i,j)`, it performs those steps globally on a 3D `ndarray` in which information on all of the neighbors at each index has been stored along the third axis (exactly like the previous `Particles.weights` array)
- `big_sliding_window` is a helper function to map all local neighbors into a 3D array. The outcome of this function matches what we would get from (a) looping over all indices `(i,j)`, (b) grabbing the local D8 neighbors with `raster[i-1:i+2,j-1:j+2]`, then (c) applying `np.ravel()` to that local array, which we store along the third axis of a new array. `big_sliding_window` just does that without looping, by mapping sub-arrays using the same order as `ravel`, i.e. [NW, N, NE, W, 0, E, SW, S, SE]
- `tile_local_array` is a helper function that maps a single local D8 raster into a 3D array in which the elements are repeated `L,W` times. This is used to get arrays like `ivec` or `distances`, which are the same everywhere, into the same space as the `weights` array.
- `tile_domain_array` is a helper function which works like `tile_local_array`, except it simply repeats a big 2D array 9 times along the vertical. When used on a raster like `stage`, the output of this function and the output of `big_sliding_window` directly match up the local values in the raster with the neighboring values. 
- Lastly, `clear_borders` is just a useful little function to set all the 2D boundaries stored in the 3D array to 0. This is to eliminate any values that show up in the `weights` array along the border during the math inside `make_weight`. 

In the test cases I've done so far, computing the weights never takes more than a few seconds. On the largest domain I could think to use (~2900 x 2000 elements), it took about 10 seconds.

For a test application, iterating 2000 particles for 10 hours in a domain (~1100 x 1100 elements) with no plotting, the previous algorithm took 4.6 minutes to finish, whereas this algorithm took almost exactly 3 minutes with similar-looking results. From what I remember of previous times the package was profiled, this 34% speedup is about how much time we were spending inside `make_weight`, which suggests to me that this function will be our problem no more. 