### PR TITLE
drop link checking, breaks for github links now

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,7 +22,6 @@ clean :
 
 
 test : clean
-	@$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)"
 	make clean
 	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)"
 


### PR DESCRIPTION
GitHub documentation links are breaking right now, so we're not going to run the auto-link checking at this time. Maybe we try turning it back on in the future or something... but it would be nice to have to docs build smoothly at this time.