### PR TITLE
Update routines.py

### DIFF
--- a/dorado/routines.py
+++ b/dorado/routines.py
@@ -566,7 +566,7 @@ def plot_exposure_time(walk_data,
     elif timedelta == 3600:
         timeunit = '[hr]'
     elif timedelta == 86400:
-        timeunit == '[day]'
+        timeunit = '[day]'
     else:
         timeunit = '[' + str(timedelta) + ' s]'
 


### PR DESCRIPTION
@elbeejay This is an error I encounter when using day as timeunit. I just deleted an '=' which fixed it on the version I use. 

Fixes this error:   
567     timeunit = '[hr]'
    568 elif timedelta == 86400:
--> 569     timeunit == '[day]'
    570 else:
    571     timeunit = '[' + str(timedelta) + ' s]'

UnboundLocalError: local variable 'timeunit' referenced before assignment