### PR TITLE
Implement logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ target/
 
 # SublimeText docs
 *.sublime-*
+
+# uv
+uv.lock

--- a/dorado/__init__.py
+++ b/dorado/__init__.py
@@ -5,3 +5,4 @@ from . import parallel_routing
 from . import particle_track
 from . import routines
 from . import spatial
+from .logging_config import setup_logging, logger

--- a/dorado/__init__.py
+++ b/dorado/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.0"
+__version__ = "2.7.0"
 
 from . import lagrangian_walker
 from . import parallel_routing

--- a/dorado/logging_config.py
+++ b/dorado/logging_config.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+Logging configuration for the dorado package.
+
+Provides centralized logging setup and backward-compatible handling
+of the deprecated `verbose` parameter.
+
+Project Homepage: https://github.com/passaH2O/dorado
+"""
+import logging
+import warnings
+
+# Package-level logger
+logger = logging.getLogger("dorado")
+
+
+def setup_logging(level="WARNING", handler=None):
+    """Configure dorado logging.
+
+    **Inputs** :
+
+        level : `str`, optional
+            Logging level. One of "DEBUG", "INFO", "WARNING", "ERROR",
+            "CRITICAL". Default is "WARNING".
+
+        handler : `logging.Handler`, optional
+            Custom logging handler. If not provided, a StreamHandler
+            writing to stderr is used.
+
+    **Example**::
+
+        import dorado
+
+        # Show informational messages
+        dorado.setup_logging("INFO")
+
+        # Log to a file
+        import logging
+        dorado.setup_logging("DEBUG", handler=logging.FileHandler("dorado.log"))
+
+    """
+    logger.setLevel(getattr(logging, level.upper()))
+    if not logger.handlers:
+        h = handler or logging.StreamHandler()
+        h.setFormatter(
+            logging.Formatter("%(name)s - %(levelname)s - %(message)s")
+        )
+        logger.addHandler(h)
+
+
+def handle_verbose_deprecation(verbose):
+    """Map deprecated verbose parameter to logging level.
+
+    This function provides backward compatibility for the deprecated
+    `verbose` parameter. It configures the logger based on the verbose
+    value and emits a deprecation warning.
+
+    **Inputs** :
+
+        verbose : `bool` or `None`
+            Legacy verbose parameter. If True, sets logging to INFO level.
+            If False, sets logging to ERROR level. If None, does nothing.
+
+    """
+    if verbose is not None:
+        warnings.warn(
+            "The 'verbose' parameter is deprecated. "
+            "Use dorado.setup_logging() instead.",
+            DeprecationWarning,
+            stacklevel=3
+        )
+        level = "INFO" if verbose else "ERROR"
+        setup_logging(level)

--- a/dorado/logging_config.py
+++ b/dorado/logging_config.py
@@ -39,7 +39,13 @@ def setup_logging(level="WARNING", handler=None):
         dorado.setup_logging("DEBUG", handler=logging.FileHandler("dorado.log"))
 
     """
-    logger.setLevel(getattr(logging, level.upper()))
+    try:
+        numeric_level = getattr(logging, level.upper())
+    except AttributeError:
+        raise ValueError(
+            f"Invalid logging level: {level}. Must be one of DEBUG, INFO, WARNING, ERROR, CRITICAL"
+        )
+    logger.setLevel(numeric_level)
     if not logger.handlers:
         h = handler or logging.StreamHandler()
         h.setFormatter(

--- a/dorado/particle_track.py
+++ b/dorado/particle_track.py
@@ -98,7 +98,7 @@ class modelParams:
             **Deprecated**. Use :func:`dorado.setup_logging` instead.
             Legacy parameter to toggle console output. If True, enables INFO
             level logging. If False, sets logging to ERROR only.
-            Default is True.
+            Default is None (equivalent to True, or INFO level logging).
 
     This list of expected parameter values can also be obtained by querying the
     class attributes with `dir(modelParams)`, `modelParams.__dict__`, or
@@ -122,7 +122,7 @@ class modelParams:
         self.qy = None
         self.u = None
         self.v = None
-        self.verbose = True  # print things by default
+        self.verbose = None
 
 
 class Particles():
@@ -142,7 +142,7 @@ class Particles():
         """
         # pass verbose (deprecated - use dorado.setup_logging() instead)
         if getattr(params, 'verbose', None) is None:
-            self.verbose = True  # set verbosity on if somehow missing
+            self.verbose = True  # set verbosity on if None or missing
         else:
             self.verbose = params.verbose
             handle_verbose_deprecation(params.verbose)

--- a/dorado/particle_track.py
+++ b/dorado/particle_track.py
@@ -15,6 +15,7 @@ from math import pi
 import numpy as np
 from tqdm import tqdm
 import dorado.lagrangian_walker as lw
+from dorado.logging_config import logger, handle_verbose_deprecation
 
 
 class modelParams:
@@ -94,9 +95,10 @@ class modelParams:
             used to route the particles. Default value is False.
 
         verbose : `bool`, optional
-            Toggles whether or not warnings and print output are output to the
-            console. If False, nothing is output, if True, messages are output.
-            Default value is True. Errors are always raised.
+            **Deprecated**. Use :func:`dorado.setup_logging` instead.
+            Legacy parameter to toggle console output. If True, enables INFO
+            level logging. If False, sets logging to ERROR only.
+            Default is True.
 
     This list of expected parameter values can also be obtained by querying the
     class attributes with `dir(modelParams)`, `modelParams.__dict__`, or
@@ -138,11 +140,12 @@ class Particles():
         possible/sensible
 
         """
-        # pass verbose
+        # pass verbose (deprecated - use dorado.setup_logging() instead)
         if getattr(params, 'verbose', None) is None:
             self.verbose = True  # set verbosity on if somehow missing
         else:
             self.verbose = params.verbose
+            handle_verbose_deprecation(params.verbose)
 
         # REQUIRED PARAMETERS #
         # Define the length along one cell face (assuming square cells)
@@ -264,8 +267,7 @@ class Particles():
         try:
             self.theta = float(params.theta)
         except Exception:
-            if self.verbose:
-                print("Theta parameter not specified - using 1.0")
+            logger.info("Theta parameter not specified - using 1.0")
             self.theta = 1.0  # if unspecified use 1
 
         # Gamma parameter used to weight the random walk
@@ -275,8 +277,7 @@ class Particles():
         try:
             self.gamma = float(params.gamma)
         except Exception:
-            if self.verbose:
-                print("Gamma parameter not specified - using 0.05")
+            logger.info("Gamma parameter not specified - using 0.05")
             self.gamma = 0.05
 
         try:
@@ -292,28 +293,24 @@ class Particles():
             self.diff_coeff = float(params.diff_coeff)
         except Exception:
             if getattr(params, 'steepest_descent', False) is True:
-                if self.verbose:
-                    print("Diffusion disabled for steepest descent")
+                logger.info("Diffusion disabled for steepest descent")
                 self.diff_coeff = 0.0
             else:
-                if self.verbose:
-                    print("Diffusion coefficient not specified - using 0.2")
+                logger.info("Diffusion coefficient not specified - using 0.2")
                 self.diff_coeff = 0.2
 
         # Minimum depth for cell to be considered wet
         try:
             self.dry_depth = params.dry_depth
         except Exception:
-            if self.verbose:
-                print("minimum depth for wetness not defined - using 10 cm")
+            logger.info("minimum depth for wetness not defined - using 10 cm")
             self.dry_depth = 0.1
 
         # Cell types: 2 = land, 1 = channel, 0 = ocean, -1 = edge
         try:
             self.cell_type = params.cell_type
         except Exception:
-            if self.verbose:
-                print("Cell Types not specified - Estimating from depth")
+            logger.info("Cell Types not specified - Estimating from depth")
             self.cell_type = np.zeros_like(self.depth, dtype='int')
             self.cell_type[self.depth < self.dry_depth] = 2
             self.cell_type = np.pad(self.cell_type[1:-1, 1:-1], 1, 'constant',
@@ -324,16 +321,13 @@ class Particles():
         # note: chooses randomly in event of ties
         try:
             if params.steepest_descent is True:
-                if self.verbose:
-                    print("Using steepest descent")
+                logger.info("Using steepest descent")
                 self.steepest_descent = True
             else:
-                if self.verbose:
-                    print("Using weighted random walk")
+                logger.info("Using weighted random walk")
                 self.steepest_descent = False
         except Exception:
-            if self.verbose:
-                print("Using weighted random walk")
+            logger.info("Using weighted random walk")
             self.steepest_descent = False
 
         # DEFAULT PARAMETERS (Can be defined otherwise) #
@@ -889,7 +883,7 @@ def ind2coord(walk_data, raster_origin, raster_size, cellsize):
 
 def exposure_time(walk_data,
                   region_of_interest,
-                  verbose=True):
+                  verbose=None):
     """Measure exposure time distribution of particles in a specified region.
 
     Function to measure the exposure time distribution (ETD) of particles to
@@ -961,10 +955,10 @@ def exposure_time(walk_data,
 
     # single print statement
     if len(_short_list) > 0:
-        if verbose:
-            print(str(len(_short_list)) + ' Particles within ROI at final'
-                  ' timestep.\n' + 'Particles are: ' + str(_short_list) +
-                  '\nRun more iterations to get full tail of ETD.')
+        handle_verbose_deprecation(verbose)
+        logger.info(str(len(_short_list)) + ' Particles within ROI at final'
+              ' timestep.\n' + 'Particles are: ' + str(_short_list) +
+              '\nRun more iterations to get full tail of ETD.')
 
     return exposure_times.tolist()
 

--- a/dorado/routines.py
+++ b/dorado/routines.py
@@ -8,6 +8,7 @@ from __future__ import division, print_function, absolute_import
 from builtins import range
 from .particle_track import Particles
 from .particle_track import modelParams
+from .logging_config import logger, handle_verbose_deprecation
 import numpy as np
 import matplotlib
 from matplotlib import pyplot as plt
@@ -23,7 +24,7 @@ import json
 # --------------------------------------------------------
 def steady_plots(particle, num_iter,
                  folder_name=None, save_output=True,
-                 verbose=True):
+                 verbose=None):
     """Automated particle movement in steady flow field.
 
     Function to automate plotting of particle movement over a steady flow
@@ -47,9 +48,10 @@ def steady_plots(particle, num_iter,
             Default value is True.
 
         verbose : `bool`, optional
-            Toggles whether or not messages print to the
-            console. If False, nothing is output, if True, messages are output.
-            Default value is True. Errors are always raised.
+            **Deprecated**. Use :func:`dorado.setup_logging` instead.
+            Legacy parameter to toggle console output. If True, enables INFO
+            level logging. If False, sets logging to ERROR only.
+            Default is None.
 
     **Outputs** :
 
@@ -67,8 +69,8 @@ def steady_plots(particle, num_iter,
         if folder_name is None:
             folder_name = os.getcwd()
         if os.path.exists(folder_name):
-            if verbose:
-                print('Saving files in existing directory')
+            handle_verbose_deprecation(verbose)
+            logger.info('Saving files in existing directory')
         else:
             os.makedirs(folder_name)
         if not os.path.exists(folder_name+os.sep+'figs'):
@@ -118,7 +120,7 @@ def steady_plots(particle, num_iter,
 
 def unsteady_plots(dx, Np_tracer, seed_xloc, seed_yloc, num_steps, timestep,
                    output_base, output_type,
-                   folder_name=None, verbose=True):
+                   folder_name=None, verbose=None):
     """Automated particle movement in unsteady flow.
 
     Function to automate plotting of particle movement in an unsteady flow
@@ -164,9 +166,10 @@ def unsteady_plots(dx, Np_tracer, seed_xloc, seed_yloc, num_steps, timestep,
             Path to folder in which to save output plots.
 
         verbose : `bool`, optional
-            Toggles whether or not messages print to the
-            console. If False, nothing is output, if True, messages are output.
-            Default value is True. Errors are always raised.
+            **Deprecated**. Use :func:`dorado.setup_logging` instead.
+            Legacy parameter to toggle console output. If True, enables INFO
+            level logging. If False, sets logging to ERROR only.
+            Default is None.
 
     **Outputs** :
 
@@ -186,8 +189,8 @@ def unsteady_plots(dx, Np_tracer, seed_xloc, seed_yloc, num_steps, timestep,
     if folder_name is None:
         folder_name = os.getcwd()
     if os.path.exists(folder_name):
-        if verbose:
-            print('Saving files in existing directory')
+        handle_verbose_deprecation(verbose)
+        logger.info('Saving files in existing directory')
     else:
         os.makedirs(folder_name)
     if not os.path.exists(folder_name+os.sep+'figs'):
@@ -208,10 +211,10 @@ def unsteady_plots(dx, Np_tracer, seed_xloc, seed_yloc, num_steps, timestep,
     qylist = sorted(qylist)
     datalist = sorted(datalist)
     if num_steps > max(len(depthlist), len(datalist)):
-        if verbose:
-            print('Warning: num_steps exceeds number of model outputs in'
-                  ' output_base')
-            print('Setting num_steps to equal number of model outputs')
+        handle_verbose_deprecation(verbose)
+        logger.warning('Warning: num_steps exceeds number of model outputs in'
+              ' output_base')
+        logger.warning('Setting num_steps to equal number of model outputs')
         num_steps = max(len(depthlist), len(datalist))
 
     # Create vector of target times
@@ -291,7 +294,7 @@ def unsteady_plots(dx, Np_tracer, seed_xloc, seed_yloc, num_steps, timestep,
     return walk_data
 
 
-def time_plots(particle, num_iter, folder_name=None, verbose=True):
+def time_plots(particle, num_iter, folder_name=None, verbose=None):
     """Steady flow plots with particle travel times visualized.
 
     Make plots with each particle's travel time visualized.
@@ -311,9 +314,10 @@ def time_plots(particle, num_iter, folder_name=None, verbose=True):
             Path to folder in which to save output plots.
 
         verbose : `bool`, optional
-            Toggles whether or not messages print to the
-            console. If False, nothing is output, if True, messages are output.
-            Default value is True. Errors are always raised.
+            **Deprecated**. Use :func:`dorado.setup_logging` instead.
+            Legacy parameter to toggle console output. If True, enables INFO
+            level logging. If False, sets logging to ERROR only.
+            Default is None.
 
     **Outputs** :
 
@@ -327,8 +331,8 @@ def time_plots(particle, num_iter, folder_name=None, verbose=True):
     if folder_name is None:
         folder_name = os.getcwd()
     if os.path.exists(folder_name):
-        if verbose:
-            print('Saving files in existing directory')
+        handle_verbose_deprecation(verbose)
+        logger.info('Saving files in existing directory')
     else:
         os.makedirs(folder_name)
     if not os.path.exists(folder_name+os.sep+'figs'):
@@ -386,7 +390,7 @@ def time_plots(particle, num_iter, folder_name=None, verbose=True):
 # --------------------------------------------------------
 # Functions for plotting/interpreting outputs
 # --------------------------------------------------------
-def get_state(walk_data, iteration=-1, verbose=True):
+def get_state(walk_data, iteration=-1, verbose=None):
     """Pull walk_data values from a specific iteration.
 
     Routine to return slices of the walk_data dict at a given iteration #.
@@ -403,9 +407,10 @@ def get_state(walk_data, iteration=-1, verbose=True):
             to -1, i.e. the most recent step
 
         verbose : `bool`, optional
-            Toggles whether or not messages print to the
-            console. If False, nothing is output, if True, messages are output.
-            Default value is True. Errors are always raised.
+            **Deprecated**. Use :func:`dorado.setup_logging` instead.
+            Legacy parameter to toggle console output. If True, enables INFO
+            level logging. If False, sets logging to ERROR only.
+            Default is None.
 
     **Outputs** :
 
@@ -441,14 +446,14 @@ def get_state(walk_data, iteration=-1, verbose=True):
             iter_exceeds_warning += 1
 
     if iter_exceeds_warning > 0:
-        if verbose:
-            print('Note: %s particles have not reached %s iterations' % \
-                  (iter_exceeds_warning, iteration))
+        handle_verbose_deprecation(verbose)
+        logger.info('Note: %s particles have not reached %s iterations' % \
+              (iter_exceeds_warning, iteration))
 
     return xinds, yinds, times
 
 
-def get_time_state(walk_data, target_time, verbose=True):
+def get_time_state(walk_data, target_time, verbose=None):
     """Pull walk_data values nearest to a specific time.
 
     Routine to return slices of the walk_data dict at a given travel time.
@@ -463,9 +468,10 @@ def get_time_state(walk_data, target_time, verbose=True):
             Travel time at which to slice the dictionary.
 
         verbose : `bool`, optional
-            Toggles whether or not messages print to the
-            console. If False, nothing is output, if True, messages are output.
-            Default value is True. Errors are always raised.
+            **Deprecated**. Use :func:`dorado.setup_logging` instead.
+            Legacy parameter to toggle console output. If True, enables INFO
+            level logging. If False, sets logging to ERROR only.
+            Default is None.
 
     **Outputs** :
 
@@ -500,8 +506,8 @@ def get_time_state(walk_data, target_time, verbose=True):
         times.append(walk_data['travel_times'][ii][tt])
 
         if times_ii[-1] < target_time:
-            if verbose:
-                print('Note: Particle '+str(ii)+' never reached target_time')
+            handle_verbose_deprecation(verbose)
+            logger.info('Note: Particle '+str(ii)+' never reached target_time')
 
     return xinds, yinds, times
 
@@ -512,7 +518,7 @@ def plot_exposure_time(walk_data,
                        timedelta=1,
                        nbins=100,
                        save_output=True,
-                       verbose=True,
+                       verbose=None,
                        uniform_timesteps=False,
                        show_thresholds=False):
     """Plot exposure time distribution of particles in a specified region.
@@ -545,9 +551,10 @@ def plot_exposure_time(walk_data,
             Default value is True.
 
         verbose : `bool`, optional
-            Toggles whether or not messages print to the
-            console. If False, nothing is output, if True, messages are output.
-            Default value is True. Errors are always raised.
+            **Deprecated**. Use :func:`dorado.setup_logging` instead.
+            Legacy parameter to toggle console output. If True, enables INFO
+            level logging. If False, sets logging to ERROR only.
+            Default is None.
                     
         uniform_timesteps: `bool`, optional
             Toggles whether or not output had a uniform timestep.
@@ -589,8 +596,8 @@ def plot_exposure_time(walk_data,
         if folder_name is None:
             folder_name = os.getcwd()
         if os.path.exists(folder_name):
-            if verbose:
-                print('Saving files in existing directory')
+            handle_verbose_deprecation(verbose)
+            logger.info('Saving files in existing directory')
         else:
             os.makedirs(folder_name)
         if not os.path.exists(folder_name+os.sep+'figs'):
@@ -676,11 +683,11 @@ def plot_exposure_time(walk_data,
                 k = int(np.searchsorted(frac_exited, lv, side='left'))  # first index where CDF >= lv
                 k = max(0, min(k, len(full_time_vect) - 1))
                 etime = full_time_vect[k] / timedelta  # same units as x-axis (days if timedelta=86400)
-                if verbose:
-                    print(f"E{int(lv*100)}: {etime:.3g} {timeunit}")
+                handle_verbose_deprecation(verbose)
+                logger.info(f"E{int(lv*100)}: {etime:.3g} {timeunit}")
             else:
-                if verbose:
-                    print(f"E{int(lv*100)}: not reached (max F={max_total:.3f})")
+                handle_verbose_deprecation(verbose)
+                logger.info(f"E{int(lv*100)}: not reached (max F={max_total:.3f})")
 
         right_ax = ax.twinx()
         right_ax.set_ylim(ax.get_ylim())
@@ -720,7 +727,7 @@ def plot_exposure_time_thresholds(walk_data,
                                   timedelta=1,
                                   nbins=100,
                                   save_output=True,
-                                  verbose=True,
+                                  verbose=None,
                                   uniform_timesteps=False):
     """Plot smoothed CDF of exposure time with E50, E75, E90 horizontal lines and labels.
         (Identical input to plot_exposure_time)
@@ -753,9 +760,10 @@ def plot_exposure_time_thresholds(walk_data,
             Default value is True.
 
         verbose : `bool`, optional
-            Toggles whether or not messages print to the
-            console. If False, nothing is output, if True, messages are output.
-            Default value is True. Errors are always raised.
+            **Deprecated**. Use :func:`dorado.setup_logging` instead.
+            Legacy parameter to toggle console output. If True, enables INFO
+            level logging. If False, sets logging to ERROR only.
+            Default is None.
             
         uniform_timesteps: `bool`, optional
             Toggles whether or not output had a uniform timestep.
@@ -835,9 +843,9 @@ def plot_exposure_time_thresholds(walk_data,
     E75_time = int(smooth_time_vect[E75_idx] / timedelta)
     E90_time = int(smooth_time_vect[E90_idx] / timedelta)
 
-    print('E50:', E50_time, timeunit)
-    print('E75:', E75_time, timeunit)
-    print('E90:', E90_time, timeunit)
+    logger.info(f'E50: {E50_time} {timeunit}')
+    logger.info(f'E75: {E75_time} {timeunit}')
+    logger.info(f'E90: {E90_time} {timeunit}')
 
     for yval in [0.5, 0.75, 0.90]:
         ax1.axhline(y=yval, color='gray', linestyle='--', linewidth=0.75)
@@ -1059,7 +1067,7 @@ def snake_plots(grid,
                 tail_length=12,
                 rgba_start=[1, 0.4, 0.2, 1],
                 rgba_end=[1, 0.3, 0.1, 0],
-                verbose=True):
+                verbose=None):
     """Plot particle positions with a trailing tail.
 
     Loops through existing walk_data history and creates a series of
@@ -1124,8 +1132,8 @@ def snake_plots(grid,
     if folder_name is None:
         folder_name = os.getcwd()
     if os.path.exists(folder_name):
-        if verbose:
-            print('Saving files in existing directory')
+        handle_verbose_deprecation(verbose)
+        logger.info('Saving files in existing directory')
     else:
         os.makedirs(folder_name)
     if not os.path.exists(folder_name+os.sep+'figs'):

--- a/dorado/routines.py
+++ b/dorado/routines.py
@@ -843,6 +843,7 @@ def plot_exposure_time_thresholds(walk_data,
     E75_time = int(smooth_time_vect[E75_idx] / timedelta)
     E90_time = int(smooth_time_vect[E90_idx] / timedelta)
 
+    handle_verbose_deprecation(verbose)
     logger.info(f'E50: {E50_time} {timeunit}')
     logger.info(f'E75: {E75_time} {timeunit}')
     logger.info(f'E90: {E90_time} {timeunit}')

--- a/dorado/routines.py
+++ b/dorado/routines.py
@@ -212,7 +212,7 @@ def unsteady_plots(dx, Np_tracer, seed_xloc, seed_yloc, num_steps, timestep,
     datalist = sorted(datalist)
     if num_steps > max(len(depthlist), len(datalist)):
         handle_verbose_deprecation(verbose)
-        logger.warning('Warning: num_steps exceeds number of model outputs in'
+        logger.warning('num_steps exceeds number of model outputs in'
               ' output_base')
         logger.warning('Setting num_steps to equal number of model outputs')
         num_steps = max(len(depthlist), len(datalist))

--- a/dorado/spatial.py
+++ b/dorado/spatial.py
@@ -63,7 +63,7 @@ def systemwide(walk_data, elevation, celltype, resolution_factor):
 
             if np.any(in_regions[r0:r1, c0:c1]):
                 chunk_walk = _find_common_indices_info(walk_data, (r0, r1), (c0, c1))
-                exp_data = pt.exposure_time(chunk_walk, regions, verbose=False)
+                exp_data = pt.exposure_time(chunk_walk, regions)
                 exposure_time_data_chunks.append(exp_data)
             else:
                 exposure_time_data_chunks.append(np.nan)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pydorado"
-version = "2.6.0"
+version = "2.7.0"
 description = "dorado - Lagrangian particle routing routine via weighted random walks"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE" }
@@ -53,6 +53,11 @@ docs = [
 
 [tool.setuptools.package-data]
 "pydorado" = ["*.txt", "*.npz"]
+
+[dependency-groups]
+dev = [
+    "pytest>=4.6.7",
+]
 
 [tool.setuptools]
 packages = ["dorado"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,5 @@ docs = [
 [tool.setuptools.package-data]
 "pydorado" = ["*.txt", "*.npz"]
 
-[dependency-groups]
-dev = [
-    "pytest>=4.6.7",
-]
-
 [tool.setuptools]
 packages = ["dorado"]


### PR DESCRIPTION
Use the logging module to properly support logging and verbosity (can print a lot via `DEBUG`, or can print nothing but errors with `ERROR`, or various levels in-between). All tests still pass.

This PR adds a deprecation warning for the existing `verbose` keyword-parameters which are will eventually be removed in favor of this new logger. For the time being, the old `verbose=False` is equivalent to setting the logging to "ERROR" and `verbose=True` is equivalent to setting the logging to "INFO".

Since this change does introduce this deprecation warning, I incremented a full minor version up to `2.7.0` if/when we fully remove support for the `verbose` parameter we'd want to move up to `3.0.0` I think as it would be a breaking change.


I think this would close #32 