### PR TITLE
Explicitly close files to prevent resource leak

### DIFF
--- a/examples/draw_anuga_particle_paths.py
+++ b/examples/draw_anuga_particle_paths.py
@@ -13,7 +13,8 @@ data = np.load(data_path)
 depth = data['depth']
 
 # load the walk data
-all_walk_data = json.load(open('steady_anuga_example'+os.sep+'data'+os.sep+'data.txt'))
+with open('steady_anuga_example'+os.sep+'data'+os.sep+'data.txt') as f:
+    all_walk_data = json.load(f)
 
 # Draw the travel path
 draw_travel_path(depth, all_walk_data, [0, 1, 2, 3],

--- a/examples/draw_deltarcm_particle_paths.py
+++ b/examples/draw_deltarcm_particle_paths.py
@@ -13,7 +13,8 @@ data = np.load(data_path)
 depth = data['depth']
 
 # load the walk data
-all_walk_data = json.load(open('steady_deltarcm_example'+os.sep+'data'+os.sep+'data.txt'))
+with open('steady_deltarcm_example'+os.sep+'data'+os.sep+'data.txt', 'r') as f:
+    all_walk_data = json.load(f)
 
 # Draw the travel path
 draw_travel_path(depth, all_walk_data, [0, 1, 2, 3],


### PR DESCRIPTION
This pull request fixes a file-handling issue in the examples. The current implementation uses `open()` without explicitly closing the file, which can potentially lead to resource leaks. While Python's garbage collector will eventually close the file once it is no longer referenced, it is generally better practice to explicitly close files or use a context manager.

This change replaces the direct `open()` call with a `with` statement to ensure proper file closure and follow Python best practices. The issue was identified during an ongoing research project.